### PR TITLE
Fix README parse example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ method:
 var csv = "a,b,c\nd,e,f";
 var a = CSV.parse(csv);
 console.log(a[0][0]); // a
-console.log(a[0][1]): // b
+console.log(a[0][1]); // b
 console.log(a[1][0]); // d
-console.log(a[1][1]): // e
+console.log(a[1][1]); // e
 ```
 
 ## Stringify Array to CSV


### PR DESCRIPTION
## Summary
- fix semicolons in `Parse CSV from text` example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fef7592148328889fa4c237a437e6