### PR TITLE
Fix delimiter handling in CSVObject.parse

### DIFF
--- a/lib/csv-object.js
+++ b/lib/csv-object.js
@@ -13,6 +13,9 @@ export class CSVObject {
         return stringify(this.rows, delimiter, eol);
     }
     parse(str, delimiter = undefined) {
+        if (delimiter === undefined) {
+            delimiter = this.options.delimiter;
+        }
         this.rows = parse(str, delimiter);
     }
     fromString(str, delimiter = undefined) {

--- a/lib/csv-object.ts
+++ b/lib/csv-object.ts
@@ -20,6 +20,9 @@ export class CSVObject {
   }
   
   parse (str: string, delimiter: string|undefined = undefined) {
+    if (delimiter === undefined) {
+      delimiter = this.options.delimiter
+    }
     this.rows = parse(str, delimiter)
   }
 

--- a/test/csv-object-test.js
+++ b/test/csv-object-test.js
@@ -49,6 +49,16 @@ describe('CSVObject', function () {
     assert.equal(res[0][0], 'Sanji');
     assert.equal(res[1][0], 'Zoro');
   });
+
+  it('parse with custom delimiter', function () {
+    const csv = new CSV.CSVObject({ delimiter: '\t', eol: '\n' });
+    csv.parse('a\tb\nc\td');
+    assert.equal(csv.getCell(0, 0), 'a');
+    assert.equal(csv.getCell(0, 1), 'b');
+    assert.equal(csv.getCell(1, 0), 'c');
+    assert.equal(csv.getCell(1, 1), 'd');
+    assert.equal(CSV.options.delimiter, ',');
+  });
 });
 
 


### PR DESCRIPTION
## Summary
- ensure `CSVObject.parse` uses its own delimiter when one isn't provided
- add regression test for parsing with a custom delimiter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683feea22f4883289e502faaf7d7c2f9